### PR TITLE
Resolve workflow issue seen by imaging node during dictionary build

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,7 +55,7 @@ runs:
 
   steps:
     - run: |
-       python -m pip install --upgrade pip setuptools==57.5.0 wheel
+       python -m pip install --upgrade pip setuptools==78.1.0 wheel
        
        # Install LDD Manager Tools
        python -m pip install pds.ldd-manager


### PR DESCRIPTION
## 🗒️ Summary

Trent Hare reported that the IMG dictionary build worked fine but suddenly got a build error:

https://github.com/pds-data-dictionaries/ldd-img/actions/runs/14344191428/job/40210440344

The problem is largely due to unbound version pins in various dependencies, and a newer package got picked up (outside of our purview). Since we can't control that, this PR simply upgrades `setuptools` to be compatible with _all_ the dependencies, including the one causing the issue (`mdutils`).

## ⚙️ Test Data and/or Report

This is GitHub Actions, so there's no great way to test this. Merge it, try to run the workflow again, hope for the best.

## ♻️ Related Issues

See email `<A3EE5E15-174A-4E48-A974-58CB673916EF@jpl.nasa.gov>`